### PR TITLE
[CLOUDSRV-4519] Moved the Error.captureStackTrace() call to the end of t...

### DIFF
--- a/lib/acsError.js
+++ b/lib/acsError.js
@@ -34,8 +34,6 @@ module.exports = ACSError;
  * @param {object} parameters - Params that are injected into placeholders in the error message.
  */
 function ACSError(errorEntry, parameters) {
-	Error.captureStackTrace(this);
-
 	errorEntry || (errorEntry = {});
 	parameters || (parameters || {});
 
@@ -46,6 +44,8 @@ function ACSError(errorEntry, parameters) {
 		this.message = this.message.replace('%' + parameter + '%', parameters[parameter]);
 		this[parameter] || (this[parameter] = parameters[parameter]);
 	}
+
+	Error.captureStackTrace(this);
 }
 
 util.inherits(ACSError, Error);


### PR DESCRIPTION
...he constructor so that the stack displays the correct error message. This will allow Mocha to display the error correctly in the event a unit test fails.