### PR TITLE
CLOUDSRV-4564 Support set default response json depth for app, and fix processWait bug

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -74,8 +74,23 @@ function acsRequest(apiEntryPoint, appOptions, httpMethod, cookieString, restOpt
 	}
 
 	// pretty_json can be set as application level from appOptions
-	if (appOptions.prettyJson) {
-		restOptions.pretty_json = true;
+	if (appOptions.prettyJson && !restOptions.hasOwnProperty("pretty_json")) {
+		if (typeof appOptions.prettyJson !== 'boolean') {
+			return callback(new ACSError(messages.ERR_WRONG_TYPE, {
+				typeName: 'prettyJson'
+			}));
+		}
+		restOptions.pretty_json = appOptions.prettyJson;
+	}
+
+	// response_json_depth can be set as application level from appOptions
+	if (appOptions.responseJsonDepth && !restOptions.hasOwnProperty("response_json_depth")) {
+		if (typeof appOptions.responseJsonDepth !== 'number') {
+			return callback(new ACSError(messages.ERR_WRONG_TYPE, {
+				typeName: 'responseJsonDepth'
+			}));
+		}
+		restOptions.response_json_depth = appOptions.responseJsonDepth;
 	}
 
 	var requestParam = null,

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -14,7 +14,8 @@ console.log('MD5 of ACS_APPKEY: %s', testUtil.md5(acsKey));
 var ACSNode = require('../index'),
 	acsApp = new ACSNode(acsKey, {
 		apiEntryPoint: acsEntryPoint,
-		prettyJson: true
+		prettyJson: true,
+		responseJsonDepth: 1
 	}),
 	acsUsername = null,
 	acsPassword = 'cocoafish',

--- a/test/testUtil.js
+++ b/test/testUtil.js
@@ -46,6 +46,9 @@ function processWait(acs, type, id, cb, interval, maxTries, i) {
 	if (!interval) {
 		interval = 2000;
 	}
+	if (!id) {
+		cb(new Error('id is undefined'));
+	}
 
 	var showMethod = type + 'sShow';
 	if (type == 'photo') {


### PR DESCRIPTION
#Ticket
Add an optional to support the default response json depth

#Description
Since we changed the default value of response_json_depth to 1, some test cases for acs-node-sdk can't work, we should add an optional value to set the default response_json_depth for an app.

#How to test
Please do the tests as test/events.test.js, add "responseJsonDepth: 1", to set the value of response_json_depth